### PR TITLE
Bug fix

### DIFF
--- a/include/relaxation_2dd-window.c
+++ b/include/relaxation_2dd-window.c
@@ -9,7 +9,7 @@ descriptor_t put_window(DS_TYPE* set, uint8_t contention)
 	
 	if(contention == 1)
 	{		
-		thread_index == random_index(set);
+		thread_index = random_index(set);
 		contention = 0;
 	}
 	


### PR DESCRIPTION
Double equals made the random contention avoidance not work for put_window in 2Dd. This should have had a noticeable impact on performance.